### PR TITLE
Add Swedish, Danish and German translations

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -14,10 +14,21 @@
     <extension point="xbmc.addon.metadata">
         <summary lang="en">Category5 TV Network Kodi Add On</summary>
         <summary lang="no">Category5 TV Network Kodi-tillegg</summary>
+        <summary lang="da">Category5 TV Network Kodi-tillegg</summary>
+        <summary lang="sv">Category5 TV Network Kodi-Tillägg</summary>
+        <summary lang="de">Category5 TV Network Kodi-plugin</summary>
         <description lang="en">Watch shows from the Category5 TV Network, including Category5 Technology TV.</description>
         <disclaimer lang="en">Please visit https://category5.tv/ for more information.</disclaimer>
         <description lang="no">Se programmer fra Category5 TV-nettverket, inkludert Category5 Technology TV.</description>
         <disclaimer lang="no">Besøk https://category5.tv/ for mer informasjon.</disclaimer>
+
+        <description lang="da">Se programmer fra kategori5 net-tv, herunder kategori5 Technology tv.</description>
+	<disclaimer lang="da">Besøg https://category5.tv/ for mere information.</disclaimer>
+        <description lang="sv">Titta på TV-nätverket Category5, inklusive Category5 Technology TV.</description>
+	<disclaimer lang="sv">Besök https://category5.tv/ för mer information.</disclaimer>
+        <description lang="de">Beobachtungen von der Kategorie5 TV-Netzwerk, einschließlich Kategorie 5 Technologie TV.</description>
+	<disclaimer lang="de">Besuchen Sie https://category5.tv/ für weitere Informationen.</disclaimer>
+	
         <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
         <website>https://category5.tv</website>
         <source>https://github.com/Cat5TV/plugin.video.category5</source>

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
     id="plugin.video.category5"
     name="Category5.TV"
-    version="1.0.16"
+    version="1.0.17"
     provider-name="Category5 TV Network">
     <requires>
         <import addon="xbmc.python" version="2.1.0" />

--- a/addon.xml
+++ b/addon.xml
@@ -12,8 +12,8 @@
         <provides>audio</provides>
     </extension>
     <extension point="xbmc.addon.metadata">
-        <summary lang="en">Category5 Add On</summary>
-        <summary lang="no">Category5-tillegg</summary>
+        <summary lang="en">Category5 TV Network Kodi Add On</summary>
+        <summary lang="no">Category5 TV Network Kodi-tillegg</summary>
         <description lang="en">Watch shows from the Category5 TV Network, including Category5 Technology TV.</description>
         <disclaimer lang="en">Please visit https://category5.tv/ for more information.</disclaimer>
         <description lang="no">Se programmer fra Category5 TV-nettverket, inkludert Category5 Technology TV.</description>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+Version 1.0.17:
+-Add Swedish, Danish and German translations
 Version 1.0.16:
 -HLS should now be working, and is set as default
 -Removed LD ("low") quality option since it is unused

--- a/resources/language/Danish/strings.xml
+++ b/resources/language/Danish/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<strings>
+
+  <!-- Settings -->
+  <string id="10000">Generell</string>
+  <string id="10001">Kvalitet</string>
+  <string id="10002">HD</string>
+  <string id="10003">SD</string>
+  <string id="10004">LD</string>
+  <string id="10005">Kun lyd</string>
+  <string id="10006">Automatisk</string>
+
+</strings>

--- a/resources/language/German/strings.xml
+++ b/resources/language/German/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<strings>
+
+  <!-- Settings -->
+  <string id="10000">General</string>
+  <string id="10001">Qualität</string>
+  <string id="10002">HD</string>
+  <string id="10003">SD</string>
+  <string id="10004">LD</string>
+  <string id="10005">Nur Audio</string>
+  <string id="10006">Automatisch</string>
+
+</strings>

--- a/resources/language/Swedish/strings.xml
+++ b/resources/language/Swedish/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<strings>
+
+  <!-- Settings -->
+  <string id="10000">Generell</string>
+  <string id="10001">Kvalitet</string>
+  <string id="10002">HD</string>
+  <string id="10003">SD</string>
+  <string id="10004">LD</string>
+  <string id="10005">Endast ljud</string>
+  <string id="10006">Automatisk</string>
+
+</strings>


### PR DESCRIPTION
Add Swedish, Danish and German translations to the Kodi plugin.