### PR TITLE
Forgot to enable Swedish, Danish and German translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # plugin.video.category5
-Category5.TV addon Offical Development for Kodi (version 1.1.0).
+Category5.TV addon Offical Development for Kodi (version 1.1.1).
 
 Watch all the episodes from the Category5 TV Network at your leisure, as well as the weekly live episodes of Category5 Technology TV.
 
@@ -21,7 +21,7 @@ Category5.TV addon can be found in Videos > Video add-ons.
 
 Please visit http://www.category5.tv/
 
-Last updated : 19th July 2017
+Last updated : 2017-10-26
 
 ## Versions
 

--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,7 @@
 <addon
     id="plugin.video.category5"
     name="Category5.TV"
-    version="1.1.0"
+    version="1.1.1"
     provider-name="Category5 TV Network">
     <requires>
         <import addon="xbmc.python" version="2.1.0" />
@@ -31,6 +31,6 @@
         <website>https://category5.tv</website>
         <source>https://github.com/Cat5TV/plugin.video.category5</source>
         <platform>all</platform>
-        <language>no en</language>
+        <language>no da sv de en</language>
     </extension>
 </addon>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Version 1.1.1:
+- Actually enable Swedish, Danish and German translations
+
 Version 1.1.0:
 - Make changelog easier to read
 - Don't list empty seasons


### PR DESCRIPTION
When I added Swedish, Danish and German translations, I forgot to enable them in the addon.xml file.
THis PR fixes that, and I incremented the version to 1.1.1 to reflect that.